### PR TITLE
Troubleshoot /clear command issue

### DIFF
--- a/clear_command_fix.md
+++ b/clear_command_fix.md
@@ -1,0 +1,99 @@
+# /clear Command Fix Documentation
+
+## Issue Description
+The `/clear` slash command was not working properly. Even after clearing the conversation history, the agent still had access to previous interactions and could reference them in subsequent responses.
+
+## Root Cause Analysis
+The issue was in the implementation of the session clearing mechanism:
+
+1. **Database-Only Clear**: The original `clear_session` method only deleted and recreated the session in the database
+2. **Stale Runner Object**: The `Runner` object in the main chat loop maintained its own internal state and conversation history, which persisted after the database session was cleared
+3. **Memory Leak**: The old conversation context remained in memory even though the database session was cleared
+
+## Fix Implementation
+
+### 1. Updated `SessionManager.clear_session` Method
+- **File**: `cli/session.py`
+- **Change**: Modified the method to return a new `Runner` instance along with the session ID
+- **Purpose**: Ensures a fresh Runner object is created for the cleared session
+
+```python
+async def clear_session(self, session_id: str) -> Tuple[Runner, str]:
+    """Clear a session and return a new Runner instance."""
+    # Delete the old session
+    await self.session_service.delete_session(...)
+    
+    # Create a new session with the same ID
+    new_session = await self.session_service.create_session(...)
+    
+    # Create a new Runner instance for the cleared session
+    new_runner = Runner(
+        agent=root_agent,
+        app_name=self.app_name,
+        session_service=self.session_service
+    )
+    
+    return new_runner, session_id
+```
+
+### 2. Updated `SlashCommandHandler.handle_clear` Method
+- **File**: `cli/slash_commands.py`
+- **Change**: Modified to return a dictionary containing the new runner and session information
+- **Purpose**: Passes the new runner back to the chat loop
+
+```python
+async def handle_clear(self, session_id: Optional[str] = None):
+    """Clear conversation history."""
+    # ... confirmation logic ...
+    
+    if confirm:
+        new_runner, new_session_id = await self.session_manager.clear_session(session_id)
+        
+        # Return the new runner and session ID
+        return {"status": "SESSION_CLEARED", "runner": new_runner, "session_id": new_session_id}
+```
+
+### 3. Updated `SlashCommandHandler.handle_command` Method
+- **File**: `cli/slash_commands.py`
+- **Change**: Modified to handle and return the dictionary from `handle_clear`
+- **Purpose**: Propagates the session clear information to the chat loop
+
+### 4. Updated Chat Loop
+- **File**: `cli/chat_loop.py`
+- **Change**: Added logic to handle session clearing by updating the runner and session ID
+- **Purpose**: Ensures the chat loop uses the new runner instance after clearing
+
+```python
+# Handle slash commands
+result = await slash_handler.handle_command(user_input, session_id)
+if result is None:  # Command was handled
+    continue
+elif isinstance(result, dict) and result.get("status") == "SESSION_CLEARED":
+    # Session was cleared, update runner and session_id
+    runner = result["runner"]
+    session_id = result["session_id"]
+    console.print(Panel(
+        f"🔄 [green]Session cleared and refreshed![/green]",
+        border_style="green",
+        padding=(0, 1)
+    ))
+    continue
+```
+
+## Testing the Fix
+After implementing these changes, the `/clear` command should:
+1. Clear the conversation history in the database
+2. Create a new `Runner` instance with no previous context
+3. Update the chat loop to use the new runner
+4. Ensure the agent has no memory of previous interactions
+
+## Benefits
+- **Complete Context Clear**: Both database and memory state are cleared
+- **Proper Session Management**: New runner instance ensures clean state
+- **User Experience**: Users can truly start fresh conversations
+- **No Memory Leaks**: Old conversation context is properly disposed of
+
+## Notes
+- The session ID remains the same after clearing (for consistency)
+- The fix maintains backward compatibility with existing functionality
+- All error handling and user confirmation flows remain unchanged

--- a/cli/chat_loop.py
+++ b/cli/chat_loop.py
@@ -149,6 +149,16 @@ async def run_chat_loop(console, runner, user_id, session_id, mcp_toolsets):
             result = await slash_handler.handle_command(user_input, session_id)
             if result is None:  # Command was handled
                 continue
+            elif isinstance(result, dict) and result.get("status") == "SESSION_CLEARED":
+                # Session was cleared, update runner and session_id
+                runner = result["runner"]
+                session_id = result["session_id"]
+                console.print(Panel(
+                    f"🔄 [green]Session cleared and refreshed![/green]",
+                    border_style="green",
+                    padding=(0, 1)
+                ))
+                continue
                 
             # Regular message
             console.print()

--- a/cli/session.py
+++ b/cli/session.py
@@ -141,20 +141,27 @@ class SessionManager:
         for toolset in mcp_toolsets:
             await toolset.close() 
 
-    async def clear_session(self, session_id: str):
-        """Clear a session."""
+    async def clear_session(self, session_id: str) -> Tuple[Runner, str]:
+        """Clear a session and return a new Runner instance."""
+        # Delete the old session
         await self.session_service.delete_session(
             app_name=self.app_name,
             user_id=self.user_id,
             session_id=session_id
         )
-        await self.session_service.create_session(
+        
+        # Create a new session with the same ID
+        new_session = await self.session_service.create_session(
             app_name=self.app_name,
             user_id=self.user_id,
             session_id=session_id
         )
-        self.console.print(Panel(
-            f"🧹 [red]Session cleared:[/red] [dim]{session_id}[/dim]",
-            border_style="red",
-            padding=(0, 2)
-        ))
+        
+        # Create a new Runner instance for the cleared session
+        new_runner = Runner(
+            agent=root_agent,
+            app_name=self.app_name,
+            session_service=self.session_service
+        )
+        
+        return new_runner, session_id


### PR DESCRIPTION
Fix `/clear` slash command to properly reset agent's in-memory conversation state.

Previously, `/clear` only reset the database session, but the `Runner` object in the main chat loop retained its in-memory conversation history, causing the agent to still 'remember' past interactions. This PR ensures a new `Runner` instance is used, providing a true fresh start.